### PR TITLE
Remove erroneous 'Test' from get GVAR popup

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,7 @@ async function activate(context) {
 		if (!gvarID) {
 			gvarID = await vscode.window.showInputBox({
 				ignoreFocusOut: true,
-				title: "What GVAR would you like to get Test?"
+				title: "What GVAR would you like to get?"
 			});
 			gvarID = gvarID.match(uuid_pattern)[0]
 		}


### PR DESCRIPTION
### Summary
Removes the string 'Test' from the new get GVAR popup.

- [x] This PR fixes an issue.
- [x] If code changes were made then they have been tested.