### PR TITLE
Return before throwing error if Get GVAR recieves no input

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,6 +48,9 @@ async function activate(context) {
 				ignoreFocusOut: true,
 				title: "What GVAR would you like to get Test?"
 			});
+			if(gvarID == undefined || gvarID == ""){
+				return
+			}
 			gvarID = gvarID.match(uuid_pattern)[0]
 		}
 


### PR DESCRIPTION
### Summary
Makes the Get GVAR input box accept cancellation and empty strings more elegantly.

- [x] This PR fixes an issue.
- [x] If code changes were made then they have been tested.
