### PR TITLE
Update to update collection information

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -174,7 +174,7 @@ async function activate(context) {
 		const baseFile = path.basename(fileName, path.extname(fileName))
 		
 		// GVAR update
-		if (fileExtension == '.gvar' && baseFile.match(uuid_pattern)){
+		if (baseFile.match(uuid_pattern)){
 			updateGVAR()
 			return
 		}

--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
 	"extensionDependencies": [
 		"vscode.python"
 	],
-	"activationEvents": [
-		"onCommand:avrae-utilities.getGvar",
-		"onCommand:avrae-utilities.updateGvar"
-	],
 	"main": "./extension.js",
 	"contributes": {
 		"commands": [
@@ -31,8 +27,12 @@
 				"title": "Avrae Utilities: Get GVAR"
 			},
 			{
-				"command": "avrae-utilities.updateGvar",
-				"title": "Avrae Utilities: Update GVAR"
+				"command": "avrae-utilities.getCollection",
+				"title": "Avrae Utilities: Get Collection"
+			},
+			{
+				"command": "avrae-utilities.pushUpdate",
+				"title": "Avrae Utilities: Push Update"
 			}
 		],
 		"languages": [
@@ -52,6 +52,12 @@
 				"id": "python",
 				"extensions": [
 					".gvar"
+				]
+			},
+			{
+				"id": "json",
+				"extensions": [
+					".io"
 				]
 			}
 		],


### PR DESCRIPTION
### Summary
Remove the updateGVAR function in favor of just an update that will check file extension, as well as the collection.io file to push updates to alias, snippets, and markdown files

Add a new command to get collection information, with the option to either get the collection.io file or pull all aliases, snippets, and readmes

I could probably do a little better with the error messages, and add the ability to just update the single file we're in, but thought I'd just try this and see what you thought. 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
